### PR TITLE
Return 'All Routes' as name of route in alerts

### DIFF
--- a/api.php
+++ b/api.php
@@ -564,6 +564,10 @@ function tcp_route_name_from_tag( $route_tag ) {
 	$r_post = get_page_by_path( $route_tag, OBJECT, 'route' );
 
 	if ( empty( $r_post ) ) {
+		
+		if ( $route_tag == 'all' ) {
+     			return 'All Routes';
+    		}
 
 		// Page doesn't exist or filter was applied
 		return $route_tag;


### PR DESCRIPTION
When an alert applies to all routes, return "All Routes" instead of "all".