### PR TITLE
Remove unused `direction_label` field from display

### DIFF
--- a/api.php
+++ b/api.php
@@ -509,12 +509,10 @@ function the_timetables( $args = array() ) {
 			$timetables->the_post();
 
 			// Get timetable metadata
-			$dir = get_post_meta( get_the_ID(), 'direction_label', true);
 			$days = get_post_meta( get_the_ID(), 'days_of_week', true);
 
 			// Create a timetable div with data attributes for optional JS manipulation
-			printf('<div class="timetable-holder" data-dir="%s" data-days="%s">', $dir, $days);
-			echo '<h2>' . $dir . '</h2>';
+			printf('<div class="timetable-holder" data-days="%s">', $days);
 			echo '<div class="subtitle">' . $days . '</div>';
 
 			// Should be HTML or an image

--- a/gtfs-update.php
+++ b/gtfs-update.php
@@ -225,7 +225,7 @@ function tcp_update_timetables( $timetable_file ) {
 			$timetable['thursday'], $timetable['friday'], $timetable['saturday'], $timetable['sunday']
 		);
 		$timetable['days_of_week'] = $days_of_week;
-		$timetable_name = trim($timetable['route_label'] . ' ' . $timetable['direction_label'] . ' ' . $timetable['days_of_week']);
+		$timetable_name = trim($timetable['route_label'] . ' ' . $timetable['days_of_week']);
 		$tag_name = str_replace(" ", "_", strtolower($timetable_name));
 		
 		// Find out if content exists in timetables folder


### PR DESCRIPTION
This removes an unused <h2> tag from timetable display