### PR TITLE
Allow alerts without an end date or start date

### DIFF
--- a/api.php
+++ b/api.php
@@ -104,19 +104,6 @@ function tcp_list_routes( $args = array() ) {
 						),
 					),
 					array(
-						'relation' => 'OR',
-						array(
-							'key'		=> 'effective_date',
-							'compare'	=> 'NOT EXISTS',
-						),
-						array(
-							'key'		=> 'effective_date',
-							'value' 	=> $dt->format("Y-m-d"),
-							'compare'	=> '<=',
-							'type'		=> 'DATE',
-						)
-					),
-					array(
 						'key'		=> 'affected_routes',
 						'value'		=> $route->post_name,
 						'compare'	=> 'LIKE',
@@ -346,32 +333,16 @@ function tcp_do_alerts( $args = array() ) {
 		'post_type'			=> 'alert',
 		'posts_per_page'	=> $args['number_posts'],
 		'meta_query' => array(
-			'relation'	=> 'AND',
+			'relation' => 'OR',
 			array(
-				'relation' => 'OR',
-				array(
-					'key'		=> 'end_date',
-					'compare'	=> 'NOT EXISTS',
-				),
-				array(
-					'key'		=> 'end_date',
-					'value' 	=> $dt->format("Y-m-d"),
-					'compare'	=> '>=',
-					'type'		=> 'DATE',
-				),
+				'key'		=> 'end_date',
+				'compare'	=> 'NOT EXISTS',
 			),
 			array(
-				'relation' => 'OR',
-				array(
-					'key'		=> 'effective_date',
-					'compare'	=> 'NOT EXISTS',
-				),
-				array(
-					'key'		=> 'effective_date',
-					'value' 	=> $dt->format("Y-m-d"),
-					'compare'	=> '<=',
-					'type'		=> 'DATE',
-				)
+				'key'		=> 'end_date',
+				'value' 	=> $dt->format("Y-m-d"),
+				'compare'	=> '>=',
+				'type'		=> 'DATE',
 			),
 		),
 	);
@@ -392,19 +363,6 @@ function tcp_do_alerts( $args = array() ) {
 					'compare'	=> '>=',
 					'type'		=> 'DATE',
 				),
-			),
-			array(
-				'relation' => 'OR',
-				array(
-					'key'		=> 'effective_date',
-					'compare'	=> 'NOT EXISTS',
-				),
-				array(
-					'key'		=> 'effective_date',
-					'value' 	=> $dt->format("Y-m-d"),
-					'compare'	=> '<=',
-					'type'		=> 'DATE',
-				)
 			),
 			array(
 				'relation' => 'OR',

--- a/api.php
+++ b/api.php
@@ -79,6 +79,11 @@ function tcp_list_routes( $args = array() ) {
 
 		if ( $args['show_alert'] ) {
 
+			// Get current date using timezone set in Wordpress
+			$timestamp = time();
+			$dt = new DateTime("now", new DateTimeZone(get_option('timezone_string')));
+			$dt->setTimestamp($timestamp);
+
 			// Query active alerts for the route
 			$query_args = array(
 				'post_type'			=> 'alert',
@@ -89,15 +94,27 @@ function tcp_list_routes( $args = array() ) {
 						'relation' => 'OR',
 						array(
 							'key'		=> 'end_date',
-							'value'		=> '',
-							'compare'	=> '==',
+							'compare'	=> 'NOT EXISTS',
 						),
 						array(
 							'key'		=> 'end_date',
-							'value' 	=> date("Y-m-d"),
+							'value' 	=> $dt->format("Y-m-d"),
 							'compare'	=> '>=',
 							'type'		=> 'DATE',
 						),
+					),
+					array(
+						'relation' => 'OR',
+						array(
+							'key'		=> 'effective_date',
+							'compare'	=> 'NOT EXISTS',
+						),
+						array(
+							'key'		=> 'effective_date',
+							'value' 	=> $dt->format("Y-m-d"),
+							'compare'	=> '<=',
+							'type'		=> 'DATE',
+						)
 					),
 					array(
 						'key'		=> 'affected_routes',
@@ -319,24 +336,42 @@ function tcp_do_alerts( $args = array() ) {
 	// Overwrite defaults with supplied $args
 	$args = wp_parse_args( $args, $defaults );
 
-	// Get alerts where the end date is either not set
-	// or is in the future.
-	// TODO: alerts with no end date are still not appearing.
+	// Get current date using timezone set in Wordpress
+	$timestamp = time();
+	$dt = new DateTime("now", new DateTimeZone(get_option('timezone_string')));
+	$dt->setTimestamp($timestamp);
+
+	// Get alerts where the end date is either not set or is in the future.
 	$query_args = array(
 		'post_type'			=> 'alert',
 		'posts_per_page'	=> $args['number_posts'],
 		'meta_query' => array(
-			'relation' => 'OR',
+			'relation'	=> 'AND',
 			array(
-				'key'		=> 'end_date',
-				'value'		=> '',
-				'compare'	=> '==',
+				'relation' => 'OR',
+				array(
+					'key'		=> 'end_date',
+					'compare'	=> 'NOT EXISTS',
+				),
+				array(
+					'key'		=> 'end_date',
+					'value' 	=> $dt->format("Y-m-d"),
+					'compare'	=> '>=',
+					'type'		=> 'DATE',
+				),
 			),
 			array(
-				'key'		=> 'end_date',
-				'value' 	=> date("Y-m-d"),
-				'compare'	=> '>=',
-				'type'		=> 'DATE',
+				'relation' => 'OR',
+				array(
+					'key'		=> 'effective_date',
+					'compare'	=> 'NOT EXISTS',
+				),
+				array(
+					'key'		=> 'effective_date',
+					'value' 	=> $dt->format("Y-m-d"),
+					'compare'	=> '<=',
+					'type'		=> 'DATE',
+				)
 			),
 		),
 	);
@@ -349,15 +384,27 @@ function tcp_do_alerts( $args = array() ) {
 				'relation' => 'OR',
 				array(
 					'key'		=> 'end_date',
-					'value'		=> '',
-					'compare'	=> '==',
+					'compare'	=> 'NOT EXISTS',
 				),
 				array(
 					'key'		=> 'end_date',
-					'value' 	=> date("Y-m-d"),
+					'value' 	=> $dt->format("Y-m-d"),
 					'compare'	=> '>=',
 					'type'		=> 'DATE',
 				),
+			),
+			array(
+				'relation' => 'OR',
+				array(
+					'key'		=> 'effective_date',
+					'compare'	=> 'NOT EXISTS',
+				),
+				array(
+					'key'		=> 'effective_date',
+					'value' 	=> $dt->format("Y-m-d"),
+					'compare'	=> '<=',
+					'type'		=> 'DATE',
+				)
 			),
 			array(
 				'relation' => 'OR',


### PR DESCRIPTION
Don't show alerts until their effective_date, if set
Use timezone set it wordpress for calculating current date

Fixes #1